### PR TITLE
Fix docs.rs links for scylla 1.5, remove dead LBP wrappers — v0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://hex.pm/packages/ex_scylla
 ```elixir
 def deps do
   [
-    {:ex_scylla, "~> 0.9.0"}
+    {:ex_scylla, "~> 0.9.1"}
   ]
 end
 ```

--- a/lib/ex_scylla/execution/execution_profile.ex
+++ b/lib/ex_scylla/execution/execution_profile.ex
@@ -3,7 +3,7 @@ defmodule ExScylla.Execution.ExecutionProfile do
 
   use ExScylla.Macros.Native,
     prefix: :ep,
-    docs_rs_path: "/scylla/transport/execution_profile/struct.ExecutionProfile.html"
+    docs_rs_path: "/scylla/client/execution_profile/struct.ExecutionProfile.html"
 
   native_f(
     func: :builder,

--- a/lib/ex_scylla/execution/execution_profile_builder.ex
+++ b/lib/ex_scylla/execution/execution_profile_builder.ex
@@ -4,7 +4,7 @@ defmodule ExScylla.Execution.ExecutionProfileBuilder do
 
   use ExScylla.Macros.Native,
     prefix: :epb,
-    docs_rs_path: "/scylla/transport/execution_profile/struct.ExecutionProfileBuilder.html"
+    docs_rs_path: "/scylla/client/execution_profile/struct.ExecutionProfileBuilder.html"
 
   @spec new :: T.execution_profile_builder()
   def new(), do: ExecutionProfile.builder()

--- a/lib/ex_scylla/execution/execution_profile_handle.ex
+++ b/lib/ex_scylla/execution/execution_profile_handle.ex
@@ -3,7 +3,7 @@ defmodule ExScylla.Execution.ExecutionProfileHandle do
 
   use ExScylla.Macros.Native,
     prefix: :eph,
-    docs_rs_path: "/scylla/transport/execution_profile/struct.ExecutionProfileHandle.html"
+    docs_rs_path: "/scylla/client/execution_profile/struct.ExecutionProfileHandle.html"
 
   native_f(
     func: :map_to_another_profile,

--- a/lib/ex_scylla/load_balancing/default_policy.ex
+++ b/lib/ex_scylla/load_balancing/default_policy.ex
@@ -1,7 +1,7 @@
 defmodule ExScylla.LoadBalancing.DefaultPolicy do
   use ExScylla.Macros.Native,
     prefix: :dp,
-    docs_rs_path: "/scylla/transport/load_balancing/struct.DefaultPolicy.html"
+    docs_rs_path: "/scylla/policies/load_balancing/struct.DefaultPolicy.html"
 
   alias ExScylla.Native
   def default(), do: Native.dp_default()

--- a/lib/ex_scylla/load_balancing/default_policy_builder.ex
+++ b/lib/ex_scylla/load_balancing/default_policy_builder.ex
@@ -3,7 +3,7 @@ defmodule ExScylla.LoadBalancing.DefaultPolicyBuilder do
 
   use ExScylla.Macros.Native,
     prefix: :dpb,
-    docs_rs_path: "/scylla/transport/load_balancing/struct.DefaultPolicyBuilder.html"
+    docs_rs_path: "/scylla/policies/load_balancing/struct.DefaultPolicyBuilder.html"
 
   native_f(
     func: :build,

--- a/lib/ex_scylla/load_balancing/latency_awareness_builder.ex
+++ b/lib/ex_scylla/load_balancing/latency_awareness_builder.ex
@@ -3,7 +3,7 @@ defmodule ExScylla.LoadBalancing.LatencyAwarenessBuilder do
 
   use ExScylla.Macros.Native,
     prefix: :lab,
-    docs_rs_path: "/scylla/transport/load_balancing/struct.LatencyAwarenessBuilder.html"
+    docs_rs_path: "/scylla/policies/load_balancing/struct.LatencyAwarenessBuilder.html"
 
   native_f(
     func: :exclusion_threshold,

--- a/lib/ex_scylla/macros/native.ex
+++ b/lib/ex_scylla/macros/native.ex
@@ -11,16 +11,36 @@ defmodule ExScylla.Macros.Native do
                     end
                   end)
 
+  @scylla_cql_version File.read!("#{File.cwd!()}/native/ex_scylla/Cargo.lock")
+                      |> String.split("[[package]]")
+                      |> Enum.find_value(nil, fn l ->
+                        case l |> String.trim() |> String.split("\n") do
+                          ["name = \"scylla-cql\"", "version = " <> version | _] ->
+                            String.trim(version, "\"")
+
+                          _ ->
+                            false
+                        end
+                      end)
+
   def scylla_version(), do: @scylla_version
+  def scylla_cql_version(), do: @scylla_cql_version
   @r ~r"> \s*(?<res>.*)\s*=\s*.*\.(?<func>.*)\(.*"
   @spec __using__(keyword) :: {:__block__, [], [{any, any, any}, ...]}
   defmacro __using__(opts) do
     prefix = Keyword.get(opts, :prefix)
     docs_rs_path = Keyword.get(opts, :docs_rs_path)
+    docs_rs_crate = Keyword.get(opts, :docs_rs_crate, :scylla)
+
+    docs_rs_base =
+      case docs_rs_crate do
+        :scylla -> "https://docs.rs/scylla/#{@scylla_version}"
+        :scylla_cql -> "https://docs.rs/scylla-cql/#{@scylla_cql_version}"
+      end
 
     docs_url =
       if docs_rs_path do
-        docs_url = "https://docs.rs/scylla/#{@scylla_version}" <> docs_rs_path
+        docs_url = docs_rs_base <> docs_rs_path
         Module.register_attribute(__CALLER__.module, :docs_rs_url, persist: true)
         Module.put_attribute(__CALLER__.module, :docs_rs_url, docs_url)
         docs_url
@@ -31,7 +51,7 @@ defmodule ExScylla.Macros.Native do
     Module.register_attribute(__CALLER__.module, :prefix, persist: true)
     Module.put_attribute(__CALLER__.module, :prefix, prefix)
 
-    for {k, v} <- Keyword.drop(opts, [:prefix, :docs_rs_path]) do
+    for {k, v} <- Keyword.drop(opts, [:prefix, :docs_rs_path, :docs_rs_crate]) do
       Module.register_attribute(__CALLER__.module, k, persist: true)
       Module.put_attribute(__CALLER__.module, k, v)
     end
@@ -76,9 +96,10 @@ defmodule ExScylla.Macros.Native do
 
     prefix = Module.get_attribute(__CALLER__.module, :prefix)
     docs_rs_url = Module.get_attribute(__CALLER__.module, :docs_rs_url)
+    docs_rs_suffix = docs_rs_method_suffix(Keyword.get(macro_args, :docs_rs_method, :default), name)
 
     doc = """
-    #{if docs_rs_url, do: "See: #{docs_rs_url}#method.#{name}"}
+    #{if docs_rs_url != "", do: "See: #{docs_rs_url}#{docs_rs_suffix}"}
     #{if doc_example != "", do: example_wrap(doc_example, example_setup)}
     """
 
@@ -136,9 +157,10 @@ defmodule ExScylla.Macros.Native do
 
     prefix = Module.get_attribute(__CALLER__.module, :prefix)
     docs_rs_url = Module.get_attribute(__CALLER__.module, :docs_rs_url)
+    docs_rs_suffix = docs_rs_method_suffix(Keyword.get(macro_args, :docs_rs_method, :default), name)
 
     async_doc = """
-    #{if docs_rs_url, do: "See: #{docs_rs_url}#method.#{name}"}
+    #{if docs_rs_url != "", do: "See: #{docs_rs_url}#{docs_rs_suffix}"}
 
     Async version of `#{as_name}`, returns: `{:ok, opaque} | {:error, any()}`\n
     Actual `result` (`#{return_spec_str}`) is sent to the calling process:\n
@@ -146,7 +168,7 @@ defmodule ExScylla.Macros.Native do
     """
 
     sync_doc = """
-    #{if docs_rs_url, do: "See: #{docs_rs_url}#method.#{name}"}
+    #{if docs_rs_url != "", do: "See: #{docs_rs_url}#{docs_rs_suffix}"}
 
     Sync version of #{as_name}\n
     Returns result (`#{return_spec_str}`)\n
@@ -193,6 +215,11 @@ defmodule ExScylla.Macros.Native do
       end
     end
   end
+
+  defp docs_rs_method_suffix(:default, name), do: "#method.#{name}"
+  defp docs_rs_method_suffix(false, _), do: ""
+  defp docs_rs_method_suffix(nil, _), do: ""
+  defp docs_rs_method_suffix(method, _) when is_atom(method), do: "#method.#{method}"
 
   defp example_wrap("", _), do: ""
 

--- a/lib/ex_scylla/session.ex
+++ b/lib/ex_scylla/session.ex
@@ -23,6 +23,7 @@ defmodule ExScylla.Session do
 
   native_f(
     func: :calculate_token_for_partition_key,
+    docs_rs_method: false,
     args: [session, keyspace, table, partition_key],
     args_spec: [T.session(), String.t(), String.t(), T.values()],
     return_spec: Token.t() | nil | {:error, SerializeValuesError.t()},
@@ -182,6 +183,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :await_timed_schema_agreement,
+    docs_rs_method: :await_schema_agreement,
     args: [session, timeout_ms],
     args_spec: [T.session(), pos_integer()],
     return_spec: {:ok, boolean()} | {:error, QueryError.t()},
@@ -228,6 +230,7 @@ defmodule ExScylla.Session do
 
   native_f(
     func: :calculate_token,
+    docs_rs_method: false,
     args: [session, prepared, values],
     args_spec: [T.session(), T.prepared_statement(), T.values()],
     return_spec: Token.t() | nil | {:error, SerializeValuesError.t() | QueryError.t()},
@@ -253,6 +256,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :execute_paged,
+    docs_rs_method: :execute_single_page,
     args: [session, prepared, values, paging_state],
     args_spec: [T.session(), T.prepared_statement(), T.values(), T.paging_state() | nil],
     return_spec: {:ok, QueryResult.t()} | {:error, QueryError.t()},
@@ -277,6 +281,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :execute_paged,
+    docs_rs_method: :execute_single_page,
     as: :execute_raw_paged,
     args: [session, prepared, values, paging_state],
     args_spec: [T.session(), T.prepared_statement(), T.values(), T.paging_state() | nil],
@@ -290,6 +295,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :execute,
+    docs_rs_method: :execute_unpaged,
     args: [session, prepared, values],
     args_spec: [T.session(), T.prepared_statement(), T.values()],
     return_spec: {:ok, QueryResult.t()} | {:error, QueryError.t()},
@@ -308,6 +314,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :execute,
+    docs_rs_method: :execute_unpaged,
     as: :execute_raw,
     args: [session, prepared, values],
     args_spec: [T.session(), T.prepared_statement(), T.values()],
@@ -321,6 +328,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :fetch_schema_version,
+    docs_rs_method: :await_schema_agreement,
     args: [session],
     args_spec: [T.session()],
     return_spec: {:ok, T.uuid()} | {:error, QueryError.t()},
@@ -346,6 +354,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :query,
+    docs_rs_method: :query_unpaged,
     args: [session, query, values],
     args_spec: [T.session(), String.t() | T.query(), T.values()],
     return_spec: {:ok, QueryResult.t()} | {:error, QueryError.t()},
@@ -375,6 +384,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :query,
+    docs_rs_method: :query_unpaged,
     as: :query_raw,
     args: [session, query, values],
     args_spec: [T.session(), String.t() | T.query(), T.values()],
@@ -390,6 +400,7 @@ defmodule ExScylla.Session do
   # # //session::s_query_iter,
   native_f_async(
     func: :query_paged,
+    docs_rs_method: :query_single_page,
     args: [session, query, values, paging_state],
     args_spec: [T.session(), String.t() | T.query(), T.values(), T.paging_state() | nil],
     return_spec: {:ok, QueryResult.t()} | {:error, QueryError.t()},
@@ -415,6 +426,7 @@ defmodule ExScylla.Session do
 
   native_f_async(
     func: :query_paged,
+    docs_rs_method: :query_single_page,
     as: :query_raw_paged,
     args: [session, query, values, paging_state],
     args_spec: [T.session(), String.t() | T.query(), T.values(), T.paging_state() | nil],

--- a/lib/ex_scylla/session_builder.ex
+++ b/lib/ex_scylla/session_builder.ex
@@ -4,7 +4,7 @@ defmodule ExScylla.SessionBuilder do
 
   use ExScylla.Macros.Native,
     prefix: :sb,
-    docs_rs_path: "/scylla/client/session_builder/struct.SessionBuilder.html"
+    docs_rs_path: "/scylla/client/session_builder/struct.GenericSessionBuilder.html"
 
   native_f(
     func: :default_execution_profile_handle,
@@ -23,6 +23,7 @@ defmodule ExScylla.SessionBuilder do
 
   native_f(
     func: :auto_schema_agreement_timeout,
+    docs_rs_method: :schema_agreement_timeout,
     args: [sb, timeout_ms],
     args_spec: [T.session_builder(), pos_integer()],
     return_spec: T.session_builder(),
@@ -193,6 +194,7 @@ defmodule ExScylla.SessionBuilder do
 
   native_f(
     func: :no_auto_schema_agreement,
+    docs_rs_method: :auto_await_schema_agreement,
     args: [sb],
     args_spec: [T.session_builder()],
     return_spec: T.session_builder(),

--- a/lib/ex_scylla/statement/prepared.ex
+++ b/lib/ex_scylla/statement/prepared.ex
@@ -6,7 +6,7 @@ defmodule ExScylla.Statement.Prepared do
 
   use ExScylla.Macros.Native,
     prefix: :ps,
-    docs_rs_path: "/scylla/statement/prepared_statement/struct.PreparedStatement.html",
+    docs_rs_path: "/scylla/statement/prepared/struct.PreparedStatement.html",
     ps_setup: """
     iex> node = Application.get_env(:ex_scylla, :test_node, "127.0.0.1:9042")
     iex> {:ok, session} = SessionBuilder.new()
@@ -174,6 +174,7 @@ defmodule ExScylla.Statement.Prepared do
 
   native_f(
     func: :get_prepared_metadata,
+    docs_rs_method: false,
     args: [ps],
     args_spec: [T.prepared_statement()],
     return_spec: PreparedMetadata.t(),

--- a/lib/ex_scylla/types/column_spec.ex
+++ b/lib/ex_scylla/types/column_spec.ex
@@ -2,7 +2,7 @@ defmodule ExScylla.Types.ColumnSpec do
   alias ExScylla.Types.TableSpec
 
   use ExScylla.Macros.Native,
-    docs_rs_path: "/scylla_cql/frame/response/result/struct.ColumnSpec.html"
+    docs_rs_path: "/scylla/frame/response/result/struct.ColumnSpec.html"
 
   native_struct(
     name: String.t(),

--- a/lib/ex_scylla/types/cql_duration.ex
+++ b/lib/ex_scylla/types/cql_duration.ex
@@ -1,6 +1,6 @@
 defmodule ExScylla.Types.CqlDuration do
   use ExScylla.Macros.Native,
-    docs_rs_path: "/scylla/frame/value/struct.CqlDuration.html"
+    docs_rs_path: "/scylla/value/struct.CqlDuration.html"
 
   native_struct(
     months: integer(),

--- a/lib/ex_scylla/types/dc_aware_round_robin_policy.ex
+++ b/lib/ex_scylla/types/dc_aware_round_robin_policy.ex
@@ -1,9 +1,0 @@
-defmodule ExScylla.Types.DcAwareRoundRobinPolicy do
-  use ExScylla.Macros.Native,
-    docs_rs_path: "/scylla/transport/load_balancing/struct.DcAwareRoundRobinPolicy.html"
-
-  native_struct(
-    local_dc: String.t(),
-    token_aware: boolean()
-  )
-end

--- a/lib/ex_scylla/types/errors/bad_keyspace_name.ex
+++ b/lib/ex_scylla/types/errors/bad_keyspace_name.ex
@@ -1,13 +1,13 @@
 defmodule ExScylla.Types.Errors.BadKeyspaceName do
   @moduledoc """
   Represents an error related to an invalid keyspace name.
-  Maps to `scylla::transport::errors::BadKeyspaceName`.
+  Maps to `scylla::errors::BadKeyspaceName`.
   """
   alias ExScylla.Macros.Native
   @type msg :: String.t()
   @typedoc """
     For more details, see:
-      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/transport/errors/enum.BadKeyspaceName.html
+      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/errors/enum.BadKeyspaceName.html
   """
   @type t ::
           {:empty, msg()}

--- a/lib/ex_scylla/types/errors/bad_query.ex
+++ b/lib/ex_scylla/types/errors/bad_query.ex
@@ -1,7 +1,7 @@
 defmodule ExScylla.Types.Errors.BadQuery do
   @moduledoc """
   Represents an error related to a bad query.
-  Maps to `scylla::transport::errors::BadQuery`.
+  Maps to `scylla::errors::BadQuery`.
   """
   alias ExScylla.Macros.Native
   alias ExScylla.Types.Errors.SerializeValuesError
@@ -9,7 +9,7 @@ defmodule ExScylla.Types.Errors.BadQuery do
   @type msg :: String.t()
   @typedoc """
     For more details, see:
-      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/transport/errors/enum.BadQuery.html
+      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/errors/enum.BadQuery.html
   """
   @type t ::
           {:serialize_values_error, SerializeValuesError.t()}

--- a/lib/ex_scylla/types/errors/db_error.ex
+++ b/lib/ex_scylla/types/errors/db_error.ex
@@ -1,13 +1,13 @@
 defmodule ExScylla.Types.Errors.DbError do
   @moduledoc """
   Represents an error returned by the database.
-  Maps to `scylla::transport::errors::DbError`.
+  Maps to `scylla::errors::DbError`.
   """
   alias ExScylla.Macros.Native
   @type msg :: String.t()
   @typedoc """
     For more details, see:
-      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/transport/errors/enum.DbError.html
+      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/errors/enum.DbError.html
   """
   @type t ::
           {:syntax_error, msg()}

--- a/lib/ex_scylla/types/errors/new_session_error.ex
+++ b/lib/ex_scylla/types/errors/new_session_error.ex
@@ -1,15 +1,16 @@
 defmodule ExScylla.Types.Errors.NewSessionError do
   @moduledoc """
   Represents an error that can occur when creating a new session.
-  Maps to `scylla::transport::errors::NewSessionError`.
+  Maps to `scylla::errors::NewSessionError`.
   """
   alias ExScylla.Macros.Native
-  alias ExScylla.Types.Errors.DbError
   alias ExScylla.Types.Errors.BadQuery
+  alias ExScylla.Types.Errors.DbError
+  alias ExScylla.Types.Errors.TranslationError
   @type msg :: String.t()
   @typedoc """
     For more details, see:
-      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/transport/errors/enum.NewSessionError.html
+      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/errors/enum.NewSessionError.html
   """
   @type t ::
           {:failed_to_resolve_any_hostname, msg()}

--- a/lib/ex_scylla/types/errors/partition_key_error.ex
+++ b/lib/ex_scylla/types/errors/partition_key_error.ex
@@ -1,13 +1,13 @@
 defmodule ExScylla.Types.Errors.PartitionKeyError do
   @moduledoc """
   Represents an error related to a partition key.
-  Maps to `scylla::statement::prepared_statement::PartitionKeyError`.
+  Maps to `scylla::statement::prepared::PartitionKeyError`.
   """
   alias ExScylla.Macros.Native
   @type msg :: String.t()
   @typedoc """
     For more details, see:
-      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/statement/prepared_statement/enum.PartitionKeyError.html
+      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/statement/prepared/enum.PartitionKeyError.html
   """
   @type t ::
           {:no_pk_index_value, msg()}

--- a/lib/ex_scylla/types/errors/query_error.ex
+++ b/lib/ex_scylla/types/errors/query_error.ex
@@ -1,7 +1,7 @@
 defmodule ExScylla.Types.Errors.QueryError do
   @moduledoc """
   Represents an error that can occur during query execution.
-  Maps to `scylla::transport::errors::QueryError`.
+  Maps to `scylla::errors::ExecutionError`.
   """
   alias ExScylla.Types.Errors.DbError
   alias ExScylla.Types.Errors.BadQuery
@@ -10,7 +10,7 @@ defmodule ExScylla.Types.Errors.QueryError do
   @type msg :: String.t()
   @typedoc """
     For more details, see:
-      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/transport/errors/enum.QueryError.html
+      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/errors/enum.ExecutionError.html
   """
   @type t ::
           {:db_error, DbError.t()}

--- a/lib/ex_scylla/types/errors/serialize_values_error.ex
+++ b/lib/ex_scylla/types/errors/serialize_values_error.ex
@@ -1,13 +1,13 @@
 defmodule ExScylla.Types.Errors.SerializeValuesError do
   @moduledoc """
   Represents an error that can occur when serializing values.
-  Maps to `scylla::frame::value::SerializeValuesError`.
+  Maps to `scylla::serialize::SerializationError`.
   """
   alias ExScylla.Macros.Native
   @type msg :: String.t()
   @typedoc """
     For more details, see:
-      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/frame/value/enum.SerializeValuesError.html
+      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/serialize/struct.SerializationError.html
   """
   @type t ::
           {:too_many_values, msg()}

--- a/lib/ex_scylla/types/errors/translation_error.ex
+++ b/lib/ex_scylla/types/errors/translation_error.ex
@@ -1,13 +1,13 @@
 defmodule ExScylla.Types.Errors.TranslationError do
   @moduledoc """
   Represents an error related to address translation.
-  Maps to `scylla::transport::errors::TranslationError`.
+  Maps to `scylla::errors::TranslationError`.
   """
   alias ExScylla.Macros.Native
   @type msg :: String.t()
   @typedoc """
     For more details, see:
-      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/transport/errors/enum.TranslationError.html
+      https://docs.rs/scylla/#{Native.scylla_version()}/scylla/errors/enum.TranslationError.html
   """
   @type t ::
           {:invalid_address_in_rule, msg()}

--- a/lib/ex_scylla/types/percentile_speculative_execution_policy.ex
+++ b/lib/ex_scylla/types/percentile_speculative_execution_policy.ex
@@ -1,7 +1,7 @@
 defmodule ExScylla.Types.PercentileSpeculativeExecutionPolicy do
   use ExScylla.Macros.Native,
     docs_rs_path:
-      "/scylla/transport/speculative_execution/struct.PercentileSpeculativeExecutionPolicy.html"
+      "/scylla/policies/speculative_execution/struct.PercentileSpeculativeExecutionPolicy.html"
 
   native_struct(
     max_retry_count: pos_integer(),

--- a/lib/ex_scylla/types/prepared_metadata.ex
+++ b/lib/ex_scylla/types/prepared_metadata.ex
@@ -3,7 +3,8 @@ defmodule ExScylla.Types.PreparedMetadata do
   alias ExScylla.Types.ColumnSpec
 
   use ExScylla.Macros.Native,
-    docs_rs_path: "/scylla/frame/response/result/struct.PreparedMetadata.html"
+    docs_rs_crate: :scylla_cql,
+    docs_rs_path: "/scylla_cql/frame/response/result/struct.PreparedMetadata.html"
 
   native_struct(
     col_count: non_neg_integer(),

--- a/lib/ex_scylla/types/query_result_raw.ex
+++ b/lib/ex_scylla/types/query_result_raw.ex
@@ -1,7 +1,9 @@
 defmodule ExScylla.Types.QueryResultRaw do
+  alias ExScylla.Macros.Native
+
   @moduledoc """
   Elixir-only decoded shape for `query_raw` / `execute_raw` performance paths (not a 1:1 Rust struct).
-  See Rust [`QueryResult`](https://docs.rs/scylla/latest/scylla/response/query_result/struct.QueryResult.html) for the driver type this wraps at the protocol level.
+  See Rust [`QueryResult`](https://docs.rs/scylla/#{Native.scylla_version()}/scylla/response/query_result/struct.QueryResult.html) for the driver type this wraps at the protocol level.
 
   A raw representation of a query result for maximum performance.
   Instead of `%ExScylla.Types.Row{columns: [{:type, value}]}`, the `rows` field

--- a/lib/ex_scylla/types/round_robin_policy.ex
+++ b/lib/ex_scylla/types/round_robin_policy.ex
@@ -1,6 +1,0 @@
-defmodule ExScylla.Types.RoundRobinPolicy do
-  use ExScylla.Macros.Native,
-    docs_rs_path: "/scylla/transport/load_balancing/struct.RoundRobinPolicy.html"
-
-  native_struct(token_aware: boolean())
-end

--- a/lib/ex_scylla/types/row.ex
+++ b/lib/ex_scylla/types/row.ex
@@ -1,6 +1,6 @@
 defmodule ExScylla.Types.Row do
   use ExScylla.Macros.Native,
-    docs_rs_path: "/scylla/frame/response/result/struct.Row.html"
+    docs_rs_path: "/scylla/value/struct.Row.html"
 
   native_struct(columns: list(term()))
 end

--- a/lib/ex_scylla/types/simple_speculative_execution_policy.ex
+++ b/lib/ex_scylla/types/simple_speculative_execution_policy.ex
@@ -1,7 +1,7 @@
 defmodule ExScylla.Types.SimpleSpeculativeExecutionPolicy do
   use ExScylla.Macros.Native,
     docs_rs_path:
-      "/scylla/transport/speculative_execution/struct.SimpleSpeculativeExecutionPolicy.html"
+      "/scylla/policies/speculative_execution/struct.SimpleSpeculativeExecutionPolicy.html"
 
   native_struct(
     max_retry_count: pos_integer(),

--- a/lib/ex_scylla/types/types.ex
+++ b/lib/ex_scylla/types/types.ex
@@ -3,8 +3,6 @@ defmodule ExScylla.Types do
   This module defines the core type hierarchy and aliases used throughout the `ExScylla` library.
   It provides Elixir type specs that map to the underlying Rust Scylla driver types.
   """
-  alias ExScylla.Types.RoundRobinPolicy
-  alias ExScylla.Types.DcAwareRoundRobinPolicy
   alias ExScylla.Types.SimpleSpeculativeExecutionPolicy
   alias ExScylla.Types.PercentileSpeculativeExecutionPolicy
   alias ExScylla.Types.CqlDuration
@@ -31,7 +29,7 @@ defmodule ExScylla.Types do
   @opaque latency_awareness_builder :: reference()
   @opaque load_balancing_policy_resource :: reference()
   @type transport_compression :: :lz4 | :snappy
-  @type load_balancing_policy :: RoundRobinPolicy.t() | DcAwareRoundRobinPolicy.t()
+  @type load_balancing_policy :: load_balancing_policy_resource()
   @type pool_size :: {:per_host, pos_integer()} | {:per_shard, pos_integer()}
   @type retry_policy :: :default_retry_policy | :fall_through_retry_policy
   @type speculative_execution_policy ::

--- a/lib/ex_scylla/types/user_defined_type.ex
+++ b/lib/ex_scylla/types/user_defined_type.ex
@@ -1,6 +1,6 @@
 defmodule ExScylla.Types.UserDefinedType do
   use ExScylla.Macros.Native,
-    docs_rs_path: "/scylla/frame/response/result/enum.CqlValue.html#variant.UserDefinedType"
+    docs_rs_path: "/scylla/value/enum.CqlValue.html#variant.UserDefinedType"
 
   alias ExScylla.Types, as: T
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExScylla.MixProject do
   def project do
     [
       app: :ex_scylla,
-      version: "0.9.0",
+      version: "0.9.1",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: LcovEx, output: "cover"],

--- a/native/ex_scylla/Cargo.lock
+++ b/native/ex_scylla/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "ex_scylla"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bigdecimal 0.2.2",
  "bytes",

--- a/native/ex_scylla/Cargo.toml
+++ b/native/ex_scylla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ex_scylla"
-version = "0.9.0"
+version = "0.9.1"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
## Summary
Updates ExDoc links to match **scylla / scylla-cql 1.5.0** on docs.rs, fixes wrong `#method.*` anchors where Elixir names differ from the Rust API, and removes Elixir modules with no NIF surface. Bumps the package to **0.9.1**.
## Changes
- **docs.rs URLs**: Replace legacy `transport/*` paths with `client/*`, `policies/*`, `value/*`, `errors/*`, `statement/prepared/*`; fix `SessionBuilder` → `GenericSessionBuilder`; host `PreparedMetadata` under **scylla-cql** via a `docs_rs_crate` option in the native macro.
- **Anchors**: Optional `docs_rs_method` on `native_f` / `native_f_async` (and `false` when there is no public rustdoc method).
- **Dead code**: Remove `RoundRobinPolicy` / `DcAwareRoundRobinPolicy`; set `load_balancing_policy` type to the opaque resource used by `DefaultPolicy` / `DefaultPolicyBuilder`.
- **Version**: `mix.exs`, `native/ex_scylla/Cargo.toml` (+ lock), README dep example → **0.9.1**.